### PR TITLE
fix PowerShell docker command

### DIFF
--- a/docs/dev/guides/dockerbuildguide.mdx
+++ b/docs/dev/guides/dockerbuildguide.mdx
@@ -60,7 +60,7 @@ N.b. Windows is not frequently tested with Netkit-JH so use at your own risk!
 > docker run --privileged --rm -v %cd%:/netkit-build -it netkitjh/netkit-builder-deb
 
 # With Powershell
-> docker run --privileged --rm -v "$(pwd)":/netkit-build -it netkitjh/netkit-builder-deb
+> docker run --privileged --rm -v ${pwd}:/netkit-build -it netkitjh/netkit-builder-deb
 ```
   </TabItem>
 </Tabs>


### PR DESCRIPTION
`"$(pwd)"` in the PowerShell Docker build command did not work. It should be `${pwd}`.