### PR TITLE
Fix link in README file

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,8 +6,7 @@ This repo hosts the source code for https://netkit-jh.github.io which covers doc
 
 == Contributing
 
-Instructions for setting up a dev environment, making posts and making pull requests are on the [site](https://netkit-jh.github.io/docs/website/start).
-
+Instructions for setting up a dev environment, making posts and making pull requests are on the https://netkit-jh.github.io/docs/website/start[site].
 
 == ToDo
 


### PR DESCRIPTION
The site link was using Markdown link syntax instead of AsciiDoc syntax.

Before:

![image](https://user-images.githubusercontent.com/18099289/105387057-13b6a800-5c0d-11eb-97ec-6576159fdf38.png)

After:

![image](https://user-images.githubusercontent.com/18099289/105387160-2a5cff00-5c0d-11eb-8fe2-d96ed23e5c28.png)
